### PR TITLE
Use shell-style word-splitting on `editor`

### DIFF
--- a/edit.py
+++ b/edit.py
@@ -13,6 +13,7 @@
 
 import os
 import os.path
+import shlex
 import subprocess
 import weechat
 
@@ -24,7 +25,7 @@ def edit(data, buf, args):
     with open(path, "w+") as f:
         f.write(weechat.buffer_get_string(buf, "input"))
 
-    cmd = editor.split() + [path]
+    cmd = shlex.split(editor) + [path]
     code = subprocess.Popen(cmd).wait()
     if code != 0:
         os.remove(path)


### PR DESCRIPTION
Use `shlex.split()` on the (possibly user-provided) editor, to avoid
passing a nonsensical list to `subprocess.Popen`.

Allow use of `plugins.var.python.edit.editor = "vim -c 'set notitle'"`,
for example, which previously was passed to `subprocess.Popen` as
`["vim", "-c", "'set", "notitle'", path]`.