### PR TITLE
Use XDG_CACHE_HOME by default

### DIFF
--- a/edit.py
+++ b/edit.py
@@ -20,12 +20,17 @@ import shlex
 import subprocess
 import weechat
 
+def xdg_cache_dir():
+    return os.path.expanduser(os.environ.get("XDG_CACHE_HOME", "~/..cache/"))
 
-def weechat_config_dir():
+def weechat_cache_dir():
+    cache_dir = os.path.join(xdg_cache_dir(), "weechat")
+    if os.path.exists(cache_dir):
+        return cache_dir
     return os.path.expanduser(os.environ.get("WEECHAT_HOME", "~/.weechat/"))
 
 
-PATH = os.path.join(weechat_config_dir(), "message.txt")
+PATH = os.path.join(weechat_cache_dir(), "message.txt")
 
 
 def editor_process_cb(data, command, return_code, out, err):

--- a/edit.py
+++ b/edit.py
@@ -21,7 +21,7 @@ import subprocess
 import weechat
 
 def xdg_cache_dir():
-    return os.path.expanduser(os.environ.get("XDG_CACHE_HOME", "~/..cache/"))
+    return os.path.expanduser(os.environ.get("XDG_CACHE_HOME", "~/.cache/"))
 
 def weechat_cache_dir():
     cache_dir = os.path.join(xdg_cache_dir(), "weechat")


### PR DESCRIPTION
Previous setup broke down when XDG Base Directory Specifications were
used.